### PR TITLE
Eliminate all compiler warnings.

### DIFF
--- a/include/chihaya/binary_arithmetic.hpp
+++ b/include/chihaya/binary_arithmetic.hpp
@@ -73,7 +73,7 @@ inline ArrayDetails fetch_seed_for_arithmetic(const H5::Group& handle, const std
  *
  * Note that any boolean types in `left` and `right` are first promoted to integer before type determination.
  */
-inline ArrayDetails validate_binary_arithmetic(const H5::Group& handle, const std::string& name, const Version& version) {
+inline ArrayDetails validate_binary_arithmetic(const H5::Group& handle, const std::string& name, const Version& version) try {
     auto left_details = fetch_seed_for_arithmetic(handle, "left", name, version);
     auto right_details = fetch_seed_for_arithmetic(handle, "right", name, version);
 
@@ -100,6 +100,8 @@ inline ArrayDetails validate_binary_arithmetic(const H5::Group& handle, const st
 
     left_details.type = determine_arithmetic_type(left_details.type, right_details.type, method);
     return left_details;
+} catch (std::exception& e) {
+    throw std::runtime_error("failed to validate binary arithmetic operation at '" + name + "'\n- " + std::string(e.what()));
 }
 
 }

--- a/include/chihaya/binary_comparison.hpp
+++ b/include/chihaya/binary_comparison.hpp
@@ -59,7 +59,7 @@ inline ArrayDetails fetch_seed_for_comparison(const H5::Group& handle, const std
  *
  * The type of the output object is always boolean.
  */
-inline ArrayDetails validate_binary_comparison(const H5::Group& handle, const std::string& name, const Version& version) {
+inline ArrayDetails validate_binary_comparison(const H5::Group& handle, const std::string& name, const Version& version) try {
     auto left_details = fetch_seed_for_comparison(handle, "left", name, version);
     auto right_details = fetch_seed_for_comparison(handle, "right", name, version);
 
@@ -90,6 +90,8 @@ inline ArrayDetails validate_binary_comparison(const H5::Group& handle, const st
 
     left_details.type = BOOLEAN;
     return left_details;
+} catch (std::exception& e) {
+    throw std::runtime_error("failed to validate binary comparison operation at '" + name + "'\n- " + std::string(e.what()));
 }
 
 }

--- a/include/chihaya/binary_logic.hpp
+++ b/include/chihaya/binary_logic.hpp
@@ -66,7 +66,7 @@ inline ArrayDetails fetch_seed_for_logic(const H5::Group& handle, const std::str
  *
  * The type of the output object is always boolean.
  */
-inline ArrayDetails validate_binary_logic(const H5::Group& handle, const std::string& name, const Version& version) {
+inline ArrayDetails validate_binary_logic(const H5::Group& handle, const std::string& name, const Version& version) try {
     auto left_details = fetch_seed_for_logic(handle, "left", name, version);
     auto right_details = fetch_seed_for_logic(handle, "right", name, version);
 
@@ -93,6 +93,8 @@ inline ArrayDetails validate_binary_logic(const H5::Group& handle, const std::st
 
     left_details.type = BOOLEAN;
     return left_details;
+} catch (std::exception& e) {
+    throw std::runtime_error("failed to validate binary arithmetic operation at '" + name + "'\n- " + std::string(e.what()));
 }
 
 }

--- a/include/chihaya/combine.hpp
+++ b/include/chihaya/combine.hpp
@@ -53,7 +53,7 @@ inline ArrayDetails validate(const H5::Group& handle, const std::string&, const 
  * Otherwise, the type of the output object is set to the most advanced `ArrayType` among all `seeds` objects.
  * For example, a mixture of `INTEGER` and `FLOAT` objects will result in a `FLOAT` output.
  */
-inline ArrayDetails validate_combine(const H5::Group& handle, const std::string& name, const Version& version) {
+inline ArrayDetails validate_combine(const H5::Group& handle, const std::string& name, const Version& version) try {
     if (!handle.exists("along") || handle.childObjType("along") != H5O_TYPE_DATASET) {
         throw std::runtime_error("expected 'along' dataset for a combine operation");
     }
@@ -97,7 +97,7 @@ inline ArrayDetails validate_combine(const H5::Group& handle, const std::string&
         if (first) {
             type = cur_seed.type;
             dimensions = cur_seed.dimensions;
-            if (along >= dimensions.size()) {
+            if (static_cast<size_t>(along) >= dimensions.size()) {
                 throw std::runtime_error("'along' should be less than the seed dimensionality for a combine operation");
             }
             first = false;
@@ -119,6 +119,8 @@ inline ArrayDetails validate_combine(const H5::Group& handle, const std::string&
     }
 
     return ArrayDetails(type, std::move(dimensions));
+} catch (std::exception& e) {
+    throw std::runtime_error("failed to validate combine operation at '" + name + "'\n- " + std::string(e.what()));
 }
 
 }

--- a/include/chihaya/constant_array.hpp
+++ b/include/chihaya/constant_array.hpp
@@ -35,7 +35,7 @@ namespace chihaya {
  * i.e., any elements in `value` with the same value as the placeholder should be treated as missing.
  * (Note that, for floating-point datasets, the placeholder itself may be NaN, so byte-wise comparison should be used when checking for missingness.)
  */
-inline ArrayDetails validate_constant_array(const H5::Group& handle, const std::string& name, const Version& version) {
+inline ArrayDetails validate_constant_array(const H5::Group& handle, const std::string& name, const Version& version) try {
     std::vector<int> dims;
     {
         auto shandle = check_vector(handle, "dimensions", "constant_array");
@@ -84,6 +84,8 @@ inline ArrayDetails validate_constant_array(const H5::Group& handle, const std::
     }
 
     return output;
+} catch (std::exception& e) {
+    throw std::runtime_error("failed to validate constant array at '" + name + "'\n- " + std::string(e.what()));
 }
 
 }

--- a/include/chihaya/custom_array.hpp
+++ b/include/chihaya/custom_array.hpp
@@ -41,8 +41,10 @@ namespace chihaya {
  * thus avoiding a redundant copy of a large arrays when we only want to preserve the delayed operations.
  * Of course, it is assumed that clients will know how to retrieve specific resources from the remotes.
  */
-inline ArrayDetails validate_custom_array(const H5::Group& handle, const std::string& name, const Version& version) {
-    return validate_minimal(handle, name, []() -> std::string { return std::string("a custom array"); }, version);
+inline ArrayDetails validate_custom_array(const H5::Group& handle, const std::string& name, const Version& version) try {
+    return validate_minimal(handle, []() -> std::string { return std::string("a custom array"); }, version);
+} catch (std::exception& e) {
+    throw std::runtime_error("failed to validate custom array at '" + name + "'\n- " + std::string(e.what()));
 }
 
 }

--- a/include/chihaya/dense_array.hpp
+++ b/include/chihaya/dense_array.hpp
@@ -63,7 +63,7 @@ namespace chihaya {
  * i.e., any elements in `data` with the same value as the placeholder should be treated as missing.
  * (Note that, for floating-point datasets, the placeholder itself may be NaN, so byte-wise comparison should be used when checking for missingness.)
  */
-inline ArrayDetails validate_dense_array(const H5::Group& handle, const std::string& name, const Version& version) {
+inline ArrayDetails validate_dense_array(const H5::Group& handle, const std::string& name, const Version& version) try {
     // Check for a 'data' group.
     if (!handle.exists("data") || handle.childObjType("data") != H5O_TYPE_DATASET) {
         throw std::runtime_error("'data' should be a dataset for a dense array");
@@ -119,6 +119,8 @@ inline ArrayDetails validate_dense_array(const H5::Group& handle, const std::str
     }
 
     return output;
+} catch (std::exception& e) {
+    throw std::runtime_error("failed to validate dense array at '" + name + "'\n- " + std::string(e.what()));
 }
 
 }

--- a/include/chihaya/dimnames.hpp
+++ b/include/chihaya/dimnames.hpp
@@ -86,14 +86,17 @@ void validate_dimnames(const H5::Group& handle, const V& dimensions, const std::
  *   If a dataset is absent, no names are attached to the corresponding dimension.
  *   It is assumed that each string in each dataset is not missing (i.e., the placeholders described in `validate_dense_array()` should not be used here).
  */
-inline ArrayDetails validate_dimnames(const H5::Group& handle, const std::string& name, const Version& version) {
+inline ArrayDetails validate_dimnames(const H5::Group& handle, const std::string& name, const Version& version) try {
     if (!handle.exists("seed") || handle.childObjType("seed") != H5O_TYPE_GROUP) {
         throw std::runtime_error("expected 'seed' group for a dimnames assignment");
     }
     auto seed_details = validate(handle.openGroup("seed"), name + "/seed", version);
     validate_dimnames(handle, seed_details.dimensions, "dimnames assignment", version);
     return seed_details;
+} catch (std::exception& e) {
+    throw std::runtime_error("failed to validate dimnames operation at '" + name + "'\n- " + std::string(e.what()));
 }
+
 
 }
 

--- a/include/chihaya/external_hdf5.hpp
+++ b/include/chihaya/external_hdf5.hpp
@@ -42,9 +42,9 @@ namespace chihaya {
  * Generally, we suggest referring to HDF5 datasets for dense arrays (see `data` in `validate_dense_array()`)
  * and to HDF5 groups for sparse matrices (see the expected children of `handle` in `validate_sparse_matrix()`).
  */
-inline ArrayDetails validate_external_hdf5(const H5::Group& handle, const std::string& name, const Version& version) {
+inline ArrayDetails validate_external_hdf5(const H5::Group& handle, const std::string& name, const Version& version) try {
     auto msg = []() -> std::string { return std::string("an external HDF5 array"); };
-    auto deets = validate_minimal(handle, name, msg, version);
+    auto deets = validate_minimal(handle, msg, version);
 
     {
         if (!handle.exists("file") || handle.childObjType("file") != H5O_TYPE_DATASET) {
@@ -69,6 +69,8 @@ inline ArrayDetails validate_external_hdf5(const H5::Group& handle, const std::s
     }
 
     return deets;
+} catch (std::exception& e) {
+    throw std::runtime_error("failed to validate external HDF5 array at '" + name + "'\n- " + std::string(e.what()));
 }
 
 }

--- a/include/chihaya/matrix_product.hpp
+++ b/include/chihaya/matrix_product.hpp
@@ -86,7 +86,7 @@ inline std::pair<ArrayDetails, bool> fetch_seed_for_product(
  * If either `left_seed` or `right_seed` are floating-point, the output type will also be `FLOAT`.
  * Otherwise, the output type will be `INTEGER`.
  */
-inline ArrayDetails validate_matrix_product(const H5::Group& handle, const std::string& name, const Version& version) {
+inline ArrayDetails validate_matrix_product(const H5::Group& handle, const std::string& name, const Version& version) try {
     auto left_details = fetch_seed_for_product(handle, "left_seed", "left_orientation", name, version);
     auto right_details = fetch_seed_for_product(handle, "right_seed", "right_orientation", name, version);
 
@@ -123,6 +123,8 @@ inline ArrayDetails validate_matrix_product(const H5::Group& handle, const std::
     }
 
     return output;
+} catch (std::exception& e) {
+    throw std::runtime_error("failed to validate matrix product at '" + name + "'\n- " + std::string(e.what()));
 }
 
 }

--- a/include/chihaya/minimal_array.hpp
+++ b/include/chihaya/minimal_array.hpp
@@ -10,7 +10,7 @@
 namespace chihaya {
 
 template<class Function>
-ArrayDetails validate_minimal(const H5::Group& handle, const std::string& name, Function fun, const Version&) {
+ArrayDetails validate_minimal(const H5::Group& handle, Function fun, const Version&) {
     if (!handle.exists("dimensions") || handle.childObjType("dimensions") != H5O_TYPE_DATASET) {
         throw std::runtime_error("expected 'dimensions' dataset for " + fun());
     }

--- a/include/chihaya/sparse_matrix.hpp
+++ b/include/chihaya/sparse_matrix.hpp
@@ -59,7 +59,7 @@ namespace chihaya {
  * i.e., any elements in `data` with the same value as the placeholder should be treated as missing.
  * (Note that, for floating-point datasets, the placeholder itself may be NaN, so byte-wise comparison should be used when checking for missingness.)
  */
-inline ArrayDetails validate_sparse_matrix(const H5::Group& handle, const std::string& name, const Version& version) {
+inline ArrayDetails validate_sparse_matrix(const H5::Group& handle, const std::string& name, const Version& version) try {
     std::vector<int> dims(2);
     {
         auto shandle = check_vector(handle, "shape", "sparse_matrix");
@@ -101,7 +101,7 @@ inline ArrayDetails validate_sparse_matrix(const H5::Group& handle, const std::s
     if (iphandle.getTypeClass() != H5T_INTEGER) {
         throw std::runtime_error("'indptr' should be integer for a sparse matrix");
     }
-    if (vector_length(iphandle) != dims[1] + 1) {
+    if (vector_length(iphandle) != static_cast<size_t>(dims[1] + 1)) {
         throw std::runtime_error("'indptr' should have length equal to the number of columns plus 1 for a sparse matrix");
     }
     std::vector<hsize_t> indptrs(dims[1] + 1);
@@ -162,6 +162,8 @@ inline ArrayDetails validate_sparse_matrix(const H5::Group& handle, const std::s
     }
 
     return ArrayDetails(type, std::vector<size_t>(dims.begin(), dims.end()));
+} catch (std::exception& e) {
+    throw std::runtime_error("failed to validate sparse matrix at '" + name + "'\n- " + std::string(e.what()));
 }
 
 }

--- a/include/chihaya/subset.hpp
+++ b/include/chihaya/subset.hpp
@@ -50,7 +50,7 @@ inline ArrayDetails validate(const H5::Group& handle, const std::string&, const 
  *
  * The type of the output object is the same as that of the `seed`; only the dimensions are changed.
  */
-inline ArrayDetails validate_subset(const H5::Group& handle, const std::string& name, const Version& version) {
+inline ArrayDetails validate_subset(const H5::Group& handle, const std::string& name, const Version& version) try {
     if (!handle.exists("seed") || handle.childObjType("seed") != H5O_TYPE_GROUP) {
         throw std::runtime_error("expected 'seed' group for a subset operation");
     }
@@ -100,6 +100,8 @@ inline ArrayDetails validate_subset(const H5::Group& handle, const std::string& 
     }
 
     return seed_details;
+} catch (std::exception& e) {
+    throw std::runtime_error("failed to validate subset operation at '" + name + "'\n- " + std::string(e.what()));
 }
 
 }

--- a/include/chihaya/subset_assignment.hpp
+++ b/include/chihaya/subset_assignment.hpp
@@ -54,7 +54,7 @@ inline ArrayDetails validate(const H5::Group& handle, const std::string&, const 
  * The type of the object is defined as the more advanced type of `seed` and `value`.
  * For example, if `seed` is `INTEGER` and `value` is `FLOAT`, the output object will be promoted to `FLOAT`.
  */
-inline ArrayDetails validate_subset_assignment(const H5::Group& handle, const std::string& name, const Version& version) {
+inline ArrayDetails validate_subset_assignment(const H5::Group& handle, const std::string& name, const Version& version) try {
     if (!handle.exists("seed") || handle.childObjType("seed") != H5O_TYPE_GROUP) {
         throw std::runtime_error("expected 'seed' group for a subset assignment");
     }
@@ -117,6 +117,8 @@ inline ArrayDetails validate_subset_assignment(const H5::Group& handle, const st
     // Promotion.
     seed_details.type = std::max(seed_details.type, value_details.type);
     return seed_details;
+} catch (std::exception& e) {
+    throw std::runtime_error("failed to validate subset assignment at '" + name + "'\n- " + std::string(e.what()));
 }
 
 }

--- a/include/chihaya/transpose.hpp
+++ b/include/chihaya/transpose.hpp
@@ -49,7 +49,7 @@ inline ArrayDetails validate(const H5::Group& handle, const std::string&, const 
  *
  * The type of the output is the same as that of `seed`; only the dimensions are altered.
  */
-inline ArrayDetails validate_transpose(const H5::Group& handle, const std::string& name, const Version& version) {
+inline ArrayDetails validate_transpose(const H5::Group& handle, const std::string& name, const Version& version) try {
     if (!handle.exists("seed") || handle.childObjType("seed") != H5O_TYPE_GROUP) {
         throw std::runtime_error("expected 'seed' group for a transpose operation");
     }
@@ -91,6 +91,8 @@ inline ArrayDetails validate_transpose(const H5::Group& handle, const std::strin
 
     seed_details.dimensions = new_dimensions;
     return seed_details;
+} catch (std::exception& e) {
+    throw std::runtime_error("failed to validate transposition at '" + name + "'\n- " + std::string(e.what()));
 }
 
 }

--- a/include/chihaya/unary_arithmetic.hpp
+++ b/include/chihaya/unary_arithmetic.hpp
@@ -107,7 +107,7 @@ inline ArrayType determine_arithmetic_type(const ArrayType& first, const ArrayTy
  *
  * Note that any boolean types in `seed` and `value` are first promoted to integer before type determination.
  */
-inline ArrayDetails validate_unary_arithmetic(const H5::Group& handle, const std::string& name, const Version& version) {
+inline ArrayDetails validate_unary_arithmetic(const H5::Group& handle, const std::string& name, const Version& version) try {
     if (!handle.exists("seed") || handle.childObjType("seed") != H5O_TYPE_GROUP) {
         throw std::runtime_error("expected 'seed' group for an unary arithmetic operation");
     }
@@ -204,6 +204,8 @@ inline ArrayDetails validate_unary_arithmetic(const H5::Group& handle, const std
     seed_details.type = determine_arithmetic_type(min_type, seed_details.type, method);
 
     return seed_details;
+} catch (std::exception& e) {
+    throw std::runtime_error("failed to validate unary arithmetic operation at '" + name + "'\n- " + std::string(e.what()));
 }
 
 }

--- a/include/chihaya/unary_comparison.hpp
+++ b/include/chihaya/unary_comparison.hpp
@@ -79,7 +79,7 @@ inline bool valid_comparison(const std::string& method) {
  *
  * The type of the output object is always boolean.
  */
-inline ArrayDetails validate_unary_comparison(const H5::Group& handle, const std::string& name, const Version& version) {
+inline ArrayDetails validate_unary_comparison(const H5::Group& handle, const std::string& name, const Version& version) try {
     if (!handle.exists("seed") || handle.childObjType("seed") != H5O_TYPE_GROUP) {
         throw std::runtime_error("expected 'seed' group for an unary comparison operation");
     }
@@ -162,6 +162,8 @@ inline ArrayDetails validate_unary_comparison(const H5::Group& handle, const std
 
     seed_details.type = BOOLEAN;
     return seed_details;
+} catch (std::exception& e) {
+    throw std::runtime_error("failed to validate binary comparison operation at '" + name + "'\n- " + std::string(e.what()));
 }
 
 }

--- a/include/chihaya/unary_logic.hpp
+++ b/include/chihaya/unary_logic.hpp
@@ -72,7 +72,7 @@ inline ArrayDetails validate(const H5::Group& handle, const std::string&, const 
  *
  * The type of the output object is always boolean.
  */
-inline ArrayDetails validate_unary_logic(const H5::Group& handle, const std::string& name, const Version& version) {
+inline ArrayDetails validate_unary_logic(const H5::Group& handle, const std::string& name, const Version& version) try {
     if (!handle.exists("seed") || handle.childObjType("seed") != H5O_TYPE_GROUP) {
         throw std::runtime_error("expected 'seed' group for an unary logic operation");
     }
@@ -164,6 +164,8 @@ inline ArrayDetails validate_unary_logic(const H5::Group& handle, const std::str
 
     seed_details.type = BOOLEAN;
     return seed_details;
+} catch (std::exception& e) {
+    throw std::runtime_error("failed to validate unary logic operation at '" + name + "'\n- " + std::string(e.what()));
 }
 
 }

--- a/include/chihaya/unary_math.hpp
+++ b/include/chihaya/unary_math.hpp
@@ -77,7 +77,7 @@ inline ArrayDetails validate(const H5::Group& handle, const std::string&, const 
  * The only exceptions are for `abs`, which is either integer or float depending on the input (booleans are promoted to integer);
  * and `sign`, which is always integer.
  */
-inline ArrayDetails validate_unary_math(const H5::Group& handle, const std::string& name, const Version& version) {
+inline ArrayDetails validate_unary_math(const H5::Group& handle, const std::string& name, const Version& version) try {
     if (!handle.exists("seed") || handle.childObjType("seed") != H5O_TYPE_GROUP) {
         throw std::runtime_error("expected 'seed' group for an unary math operation");
     }
@@ -158,6 +158,8 @@ inline ArrayDetails validate_unary_math(const H5::Group& handle, const std::stri
     }
 
     return seed_details;
+} catch (std::exception& e) {
+    throw std::runtime_error("failed to validate unary math operation at '" + name + "'\n- " + std::string(e.what()));
 }
 
 }

--- a/include/chihaya/unary_special_check.hpp
+++ b/include/chihaya/unary_special_check.hpp
@@ -53,7 +53,7 @@ inline ArrayDetails validate(const H5::Group& handle, const std::string&, const 
  *
  * The type of the output object is always boolean.
  */
-inline ArrayDetails validate_unary_special_check(const H5::Group& handle, const std::string& name, const Version& version) {
+inline ArrayDetails validate_unary_special_check(const H5::Group& handle, const std::string& name, const Version& version) try {
     if (!handle.exists("seed") || handle.childObjType("seed") != H5O_TYPE_GROUP) {
         throw std::runtime_error("expected 'seed' group for an unary special check");
     }
@@ -84,6 +84,8 @@ inline ArrayDetails validate_unary_special_check(const H5::Group& handle, const 
 
     seed_details.type = BOOLEAN;
     return seed_details;
+} catch (std::exception& e) {
+    throw std::runtime_error("failed to validate unary special check operation at '" + name + "'\n- " + std::string(e.what()));
 }
 
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -44,6 +44,7 @@ target_link_libraries(
 
 find_package(HDF5 REQUIRED COMPONENTS C CXX)
 target_link_libraries(libtest hdf5::hdf5 hdf5::hdf5_cpp)
+target_compile_options(libtest PRIVATE -Wall -Wextra -Wpedantic -Werror)
 
 set(CODE_COVERAGE OFF CACHE BOOL "Enable coverage testing")
 if(CODE_COVERAGE AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")


### PR DESCRIPTION
This mostly relates to the unused 'name' argument, which is now used in a function-level try/catch to give a nicer traceback.